### PR TITLE
*: replace github.com/envoyproxy with github.com/saltosystems

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/envoyproxy/protoc-gen-validate
+module github.com/saltosystems/protoc-gen-validate
 
 go 1.12
 

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/envoyproxy/protoc-gen-validate/module"
 	pgs "github.com/lyft/protoc-gen-star"
 	pgsgo "github.com/lyft/protoc-gen-star/lang/go"
+	"github.com/saltosystems/protoc-gen-validate/module"
 	"google.golang.org/protobuf/types/pluginpb"
 )
 

--- a/module/checker.go
+++ b/module/checker.go
@@ -6,8 +6,8 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/envoyproxy/protoc-gen-validate/validate"
-	"github.com/lyft/protoc-gen-star"
+	pgs "github.com/lyft/protoc-gen-star"
+	"github.com/saltosystems/protoc-gen-validate/validate"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"

--- a/module/validate.go
+++ b/module/validate.go
@@ -1,11 +1,12 @@
 package module
 
 import (
-	"github.com/envoyproxy/protoc-gen-validate/templates"
-	"github.com/envoyproxy/protoc-gen-validate/templates/java"
+	"strings"
+
 	pgs "github.com/lyft/protoc-gen-star"
 	pgsgo "github.com/lyft/protoc-gen-star/lang/go"
-	"strings"
+	"github.com/saltosystems/protoc-gen-validate/templates"
+	"github.com/saltosystems/protoc-gen-validate/templates/java"
 )
 
 const (

--- a/templates/cc/register.go
+++ b/templates/cc/register.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/envoyproxy/protoc-gen-validate/templates/shared"
 	"github.com/iancoleman/strcase"
 	pgs "github.com/lyft/protoc-gen-star"
 	pgsgo "github.com/lyft/protoc-gen-star/lang/go"
+	"github.com/saltosystems/protoc-gen-validate/templates/shared"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )

--- a/templates/go/register.go
+++ b/templates/go/register.go
@@ -3,8 +3,8 @@ package golang
 import (
 	"text/template"
 
-	"github.com/lyft/protoc-gen-star"
-	"github.com/envoyproxy/protoc-gen-validate/templates/goshared"
+	pgs "github.com/lyft/protoc-gen-star"
+	"github.com/saltosystems/protoc-gen-validate/templates/goshared"
 )
 
 func Register(tpl *template.Template, params pgs.Parameters) {

--- a/templates/goshared/register.go
+++ b/templates/goshared/register.go
@@ -11,9 +11,9 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/envoyproxy/protoc-gen-validate/templates/shared"
 	pgs "github.com/lyft/protoc-gen-star"
 	pgsgo "github.com/lyft/protoc-gen-star/lang/go"
+	"github.com/saltosystems/protoc-gen-validate/templates/shared"
 )
 
 func Register(tpl *template.Template, params pgs.Parameters) {

--- a/templates/java/register.go
+++ b/templates/java/register.go
@@ -8,10 +8,10 @@ import (
 	"text/template"
 	"unicode"
 
-	"github.com/envoyproxy/protoc-gen-validate/templates/shared"
 	"github.com/iancoleman/strcase"
 	pgs "github.com/lyft/protoc-gen-star"
 	pgsgo "github.com/lyft/protoc-gen-star/lang/go"
+	"github.com/saltosystems/protoc-gen-validate/templates/shared"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )

--- a/templates/pkg.go
+++ b/templates/pkg.go
@@ -3,12 +3,12 @@ package templates
 import (
 	"text/template"
 
-	"github.com/lyft/protoc-gen-star"
-	"github.com/lyft/protoc-gen-star/lang/go"
-	"github.com/envoyproxy/protoc-gen-validate/templates/cc"
-	"github.com/envoyproxy/protoc-gen-validate/templates/go"
-	"github.com/envoyproxy/protoc-gen-validate/templates/java"
-	"github.com/envoyproxy/protoc-gen-validate/templates/shared"
+	pgs "github.com/lyft/protoc-gen-star"
+	pgsgo "github.com/lyft/protoc-gen-star/lang/go"
+	"github.com/saltosystems/protoc-gen-validate/templates/cc"
+	golang "github.com/saltosystems/protoc-gen-validate/templates/go"
+	"github.com/saltosystems/protoc-gen-validate/templates/java"
+	"github.com/saltosystems/protoc-gen-validate/templates/shared"
 )
 
 type RegisterFn func(tpl *template.Template, params pgs.Parameters)

--- a/templates/shared/context.go
+++ b/templates/shared/context.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/envoyproxy/protoc-gen-validate/validate"
 	pgs "github.com/lyft/protoc-gen-star"
+	"github.com/saltosystems/protoc-gen-validate/validate"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/templates/shared/disabled.go
+++ b/templates/shared/disabled.go
@@ -1,8 +1,8 @@
 package shared
 
 import (
-	"github.com/envoyproxy/protoc-gen-validate/validate"
-	"github.com/lyft/protoc-gen-star"
+	pgs "github.com/lyft/protoc-gen-star"
+	"github.com/saltosystems/protoc-gen-validate/validate"
 )
 
 // Disabled returns true if validations are disabled for msg

--- a/templates/shared/well_known.go
+++ b/templates/shared/well_known.go
@@ -1,8 +1,8 @@
 package shared
 
 import (
-	"github.com/envoyproxy/protoc-gen-validate/validate"
-	"github.com/lyft/protoc-gen-star"
+	pgs "github.com/lyft/protoc-gen-star"
+	"github.com/saltosystems/protoc-gen-validate/validate"
 )
 
 type WellKnown string

--- a/tests/harness/executor/cases.go
+++ b/tests/harness/executor/cases.go
@@ -4,9 +4,9 @@ import (
 	"math"
 	"time"
 
-	cases "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/go"
-	other_package "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/other_package/go"
-	yet_another_package "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/yet_another_package/go"
+	cases "github.com/saltosystems/protoc-gen-validate/tests/harness/cases/go"
+	other_package "github.com/saltosystems/protoc-gen-validate/tests/harness/cases/other_package/go"
+	yet_another_package "github.com/saltosystems/protoc-gen-validate/tests/harness/cases/yet_another_package/go"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"

--- a/tests/harness/executor/harness.go
+++ b/tests/harness/executor/harness.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"sync"
 
-	harness "github.com/envoyproxy/protoc-gen-validate/tests/harness/go"
+	harness "github.com/saltosystems/protoc-gen-validate/tests/harness/go"
 	"golang.org/x/net/context"
 	"google.golang.org/protobuf/proto"
 )

--- a/tests/harness/executor/worker.go
+++ b/tests/harness/executor/worker.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	harness "github.com/envoyproxy/protoc-gen-validate/tests/harness/go"
+	harness "github.com/saltosystems/protoc-gen-validate/tests/harness/go"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )

--- a/tests/harness/go/main/harness.go
+++ b/tests/harness/go/main/harness.go
@@ -6,11 +6,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/go"
-	_ "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/go"
-	_ "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/other_package/go"
-	_ "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/yet_another_package/go"
-	"github.com/envoyproxy/protoc-gen-validate/tests/harness/go"
+	_ "github.com/saltosystems/protoc-gen-validate/tests/harness/cases/go"
+	_ "github.com/saltosystems/protoc-gen-validate/tests/harness/cases/other_package/go"
+	_ "github.com/saltosystems/protoc-gen-validate/tests/harness/cases/yet_another_package/go"
 	"google.golang.org/protobuf/proto"
 )
 


### PR DESCRIPTION
This change replaces the github.com/envoyproxy in favor of
github.com/saltosystems to treat it like our own. The reasoning behind
this is mainly because we wanted to vendor it on our internal building
pipelines. Before this change it wasn't possible as the `go install`
commands considers there is a mismatch between the place from where
we're importing the package and the actual name used to define the
module.