### PR TITLE
templates/go: fix a regression with file.go

### DIFF
--- a/templates/go/file.go
+++ b/templates/go/file.go
@@ -41,7 +41,7 @@ var (
 	_ = sort.Sort
 
 	{{ range $pkg, $path := enumPackages (externalEnums .) }}
-		_ = {{ $pkg }}.{{ (index (externalEnums $) 0).Parent.Name }}_{{ (index (externalEnums $) 0).Name }}(0)
+	_ = {{ $pkg }}.{{ (index (externalEnums $) 0).Name }}(0)
 	{{ end }}
 )
 


### PR DESCRIPTION
References to packages weren't used correctly.