### PR TITLE
templates/go: fix a regression with file.go (take 2)

### DIFF
--- a/templates/go/file.go
+++ b/templates/go/file.go
@@ -40,8 +40,8 @@ var (
 	_ = anypb.Any{}
 	_ = sort.Sort
 
-	{{ range $pkg, $path := enumPackages (externalEnums .) }}
-	_ = {{ $pkg }}.{{ (index (externalEnums $) 0).Name }}(0)
+	{{ range (externalEnums .) }}
+	_ = {{ pkg . }}.{{ name . }}(0)
 	{{ end }}
 )
 


### PR DESCRIPTION
References to packages weren't used correctly.

See:
* https://github.com/envoyproxy/protoc-gen-validate/issues/552
* https://github.com/envoyproxy/protoc-gen-validate/pull/549