### PR TITLE
*: fix external enums generation

### DIFF
--- a/templates/go/file.go
+++ b/templates/go/file.go
@@ -22,7 +22,7 @@ import (
 
 	{{ range $pkg, $path := enumPackages (externalEnums .) }}
 		{{ $pkg }} "{{ $path }}"
-	{{ end }}
+	{{- end }}
 )
 
 // ensure the imports are used
@@ -42,7 +42,7 @@ var (
 
 	{{ range (externalEnums .) }}
 	_ = {{ pkg . }}.{{ name . }}(0)
-	{{ end }}
+	{{- end }}
 )
 
 {{- if fileneeds . "uuid" }}

--- a/templates/goshared/register.go
+++ b/templates/goshared/register.go
@@ -317,7 +317,7 @@ func (fns goSharedFuncs) externalEnums(file pgs.File) []pgs.Enum {
 				en = fld.Type().Element().Enum()
 			}
 
-			if en != nil && en.Package().ProtoName() != fld.Package().ProtoName() && fns.PackageName(en) != fns.PackageName(fld) {
+			if en != nil && fns.PackageName(en) != fns.PackageName(fld) {
 				out = append(out, en)
 			}
 		}


### PR DESCRIPTION
Remove the condition that was excluding the enum types
generation when the enum package protoname and the field
package protoname match.