### PR TITLE
templates/go/message.go: fix paths on the nested messages

### DIFF
--- a/templates/go/message.go
+++ b/templates/go/message.go
@@ -22,13 +22,15 @@ const messageTpl = `
 						}
 				}
 			} else if len(paths) > 0 {
+				var childPaths []string
 				for i, path := range paths {
 					if strings.Index(path, "{{ $f.Name }}.") == 0 {
 						paths[i] = paths[i][len("{{ $f.Name }}."):]
+						childPaths = append(childPaths,paths[i][len("{{ $f.Name }}."):])
 					}
 				}
 				if v, ok := interface{}({{ accessor . }}).(interface{ ValidateAllWithPaths([]string) error }); ok {
-					if err := v.ValidateAllWithPaths(paths); err != nil {
+					if err := v.ValidateAllWithPaths(childPaths); err != nil {
 						errors = append(errors, {{ errCause . "err" "embedded message failed validation" }})
 					}
 				}
@@ -41,13 +43,14 @@ const messageTpl = `
 					}
 				}
 			} else if len(paths) > 0 {
+				var childPaths []string
 				for i, path := range paths {
 					if strings.Index(path, "{{ $f.Name }}.") == 0 {
-						paths[i] = paths[i][len("{{ $f.Name }}."):]
+						childPaths = append(childPaths,paths[i][len("{{ $f.Name }}."):])
 					}
 				}
 				if v, ok := interface{}({{ accessor . }}).(interface{ ValidateWithPaths([]string) error }); ok {
-					if err := v.ValidateWithPaths(paths); err != nil {
+					if err := v.ValidateWithPaths(childPaths); err != nil {
 						return {{ errCause . "err" "embedded message failed validation" }}
 					}
 				}


### PR DESCRIPTION
When validating a message with nested messages with some paths present, we are manipulating the paths to send to the nested message validation the paths without the parent prefix.

This is correct, but the legacy code was not doing it correctly, because:
 1. It was modifying the general path variable
 2. The nested message validation was receiving paths that was not belonging to him.

Imagine an InstallationUpdate request, with this update_mask:
 - `digital_key_art.background_image", "last_zone_id"`

On the digital_key_art validation, we would change the paths to:
 - `"background_image", "last_zone_id"`

We had two problems here.
  1. To the digital_key_art validation, we send this two paths to validate, but the last one (`last_zone_id`) does not make sense.
  2. Next field validations would have the original paths modified.

Even if actually is not causing any problem, it is not logically correct and we should:
  1. Do not modify the paths variable
  2. Send to the nested validation only the paths that belongs to him.