### PR TITLE
templates/go/message.go: fix paths on the nested messages (take2)

### DIFF
--- a/templates/go/message.go
+++ b/templates/go/message.go
@@ -29,7 +29,7 @@ const messageTpl = `
 						childPaths = append(childPaths,paths[i][len("{{ $f.Name }}."):])
 					}
 				}
-				if v, ok := interface{}({{ accessor . }}).(interface{ ValidateAllWithPaths([]string) error }); ok {
+				if v, ok := interface{}({{ accessor . }}).(interface{ ValidateAllWithPaths([]string) error }); ok && len(childPaths) > 0 {
 					if err := v.ValidateAllWithPaths(childPaths); err != nil {
 						errors = append(errors, {{ errCause . "err" "embedded message failed validation" }})
 					}
@@ -49,7 +49,7 @@ const messageTpl = `
 						childPaths = append(childPaths,paths[i][len("{{ $f.Name }}."):])
 					}
 				}
-				if v, ok := interface{}({{ accessor . }}).(interface{ ValidateWithPaths([]string) error }); ok {
+				if v, ok := interface{}({{ accessor . }}).(interface{ ValidateWithPaths([]string) error }); ok && len(childPaths) > 0 {
 					if err := v.ValidateWithPaths(childPaths); err != nil {
 						return {{ errCause . "err" "embedded message failed validation" }}
 					}


### PR DESCRIPTION
Last PR introduces a new bug: https://github.com/saltosystems/protoc-gen-validate/pull/11

If there are no paths related to the nested message, the validation is performed with an empty paths, leading to validate all fields.

This PR avoids to perform the validation when there are no paths related to the nested message.

Example of the generated code:
https://github.com/private-saltoapis/saltoapis-go/pull/502/commits/f1d17271ecdf7c085591deda028cdd05c1c8426e